### PR TITLE
add sharing_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note: sharing_id is optional. It is used e.g. when the API key is registered to 
 import "github.com/tiramiseb/go-gandi-livedns"
 apikey := "<the API key>"
 sharing_id := "<the sharing_id for that domain, may be nil>"
-g := gandi.New(apikey,sharing_id)
+g := gandi.New(apikey, sharing_id)
 // Step 2: create the zone
 zone := g.CreateZone("example.com Zone")
 // Step 3: create DNS records

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Example
 This example mimics the steps of [the official LiveDNS documentation example](http://doc.livedns.gandi.net/#quick-example).
 
 First (step 1), [get your API key](https://account.gandi.net/) from the "Security" section in new Account admin panel to be able to make authenticated requests to the API.
-
+Note: sharing_id is optional. It is used e.g. when the API key is registered to a user, where the domain you want to manage is not registered with that user (but the user does have rights on that zone/organization).
 ```go
 import "github.com/tiramiseb/go-gandi-livedns"
 apikey := "<the API key>"
-g := gandi.New(apikey)
+sharing_id := "<the sharing_id for that domain, may be nil>"
+g := gandi.New(apikey,sharing_id)
 // Step 2: create the zone
 zone := g.CreateZone("example.com Zone")
 // Step 3: create DNS records

--- a/cmd/gandi.go
+++ b/cmd/gandi.go
@@ -33,13 +33,14 @@ var (
 	action       = kingpin.Arg("action", "Action (valid actions depend on the type - if you provide an erroneous action, a list of allowed actions will be displayed)").Required().String()
 	args         = kingpin.Arg("args", "Arguments to the action (valid arguments depend on the action)").Strings()
 	apiKey       = kingpin.Flag("key", "The Gandi LiveDNS API key (may be stored in the GANDI_KEY environment variable)").OverrideDefaultFromEnvar("GANDI_KEY").Short('k').String()
+	sharing_id   = kingpin.Flag("sharing_id", "The Gandi LiveDNS sharing_id (may be stored in the GANDI_SHARING_ID environment variable)").OverrideDefaultFromEnvar("GANDI_SHARING_ID").Short('i').String()
 	g            *gandi.Gandi
 )
 
 func main() {
 	kingpin.CommandLine.HelpFlag.Short('h')
 	kingpin.Parse()
-	g = gandi.New(*apiKey)
+	g = gandi.New(*apiKey,*sharing_id)
 	switch *resourceType {
 	case "zone":
 		zone()

--- a/cmd/gandi.go
+++ b/cmd/gandi.go
@@ -40,7 +40,7 @@ var (
 func main() {
 	kingpin.CommandLine.HelpFlag.Short('h')
 	kingpin.Parse()
-	g = gandi.New(*apiKey,*sharing_id)
+	g = gandi.New(*apiKey, *sharing_id)
 	switch *resourceType {
 	case "zone":
 		zone()

--- a/gandi.go
+++ b/gandi.go
@@ -22,9 +22,9 @@ const (
 
 // Gandi makes it easier to interact with Gandi LiveDNS
 type Gandi struct {
-	apikey string
+	apikey     string
 	sharing_id string
-	debug  bool
+	debug      bool
 }
 
 // New instantiates a new Gandi instance
@@ -81,10 +81,10 @@ func (g *Gandi) doAskGandi(method, path string, params []byte, extraHeaders [][2
 		req *http.Request
 	)
 	client := &http.Client{}
-        suffix := ""
-        if len(g.sharing_id) != 0 {
-	        suffix += "?sharing_id="+g.sharing_id
-        }
+	suffix := ""
+	if len(g.sharing_id) != 0 {
+		suffix += "?sharing_id=" + g.sharing_id
+	}
 	if params != nil && string(params) != "null" {
 		req, err = http.NewRequest(method, gandiEndpoint+path+suffix, bytes.NewReader(params))
 	} else {

--- a/gandi.go
+++ b/gandi.go
@@ -23,12 +23,13 @@ const (
 // Gandi makes it easier to interact with Gandi LiveDNS
 type Gandi struct {
 	apikey string
+	sharing_id string
 	debug  bool
 }
 
 // New instantiates a new Gandi instance
-func New(apikey string) *Gandi {
-	return &Gandi{apikey: apikey}
+func New(apikey string, sharing_id string) *Gandi {
+	return &Gandi{apikey: apikey, sharing_id: sharing_id}
 }
 
 func (g *Gandi) askGandi(method, path string, params, recipient interface{}) (http.Header, error) {
@@ -80,10 +81,14 @@ func (g *Gandi) doAskGandi(method, path string, params []byte, extraHeaders [][2
 		req *http.Request
 	)
 	client := &http.Client{}
+        suffix := ""
+        if len(g.sharing_id) != 0 {
+	        suffix += "?sharing_id="+g.sharing_id
+        }
 	if params != nil && string(params) != "null" {
-		req, err = http.NewRequest(method, gandiEndpoint+path, bytes.NewReader(params))
+		req, err = http.NewRequest(method, gandiEndpoint+path+suffix, bytes.NewReader(params))
 	} else {
-		req, err = http.NewRequest(method, gandiEndpoint+path, nil)
+		req, err = http.NewRequest(method, gandiEndpoint+path+suffix, nil)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
API keys are registered under a Gandi User account. Domains created outside this user account can't be properly managed by the API keys, unless a sharing_id is provided. E.g. creating and assigning a TSIG key to a domain can only be done if the TSIG key is created with the sharing_id as part of the request, and can only be added/listed to the domain if the sharing_id is again provided. 
It is entirely optional in the terraform 'provider' section to add, and optional when using the CLI version. 
Both terraform-provider-gandi and go-gandi-livedns and it's command line have been validated to work with this option. 